### PR TITLE
add dobule quotes for env variable to support more than one hystrix.stre...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ ADD ./turbine-executable-2.0.0-DP.3-SNAPSHOT.jar /app/turbine.jar
 
 EXPOSE 8000
 
-CMD java -jar turbine.jar --port 8000 --streams $TURBINE_STREAMS
+CMD java -jar turbine.jar --port 8000 --streams "$TURBINE_STREAMS"


### PR DESCRIPTION
hello，this images can not support more than one hystrix.stream under my docker 1.5, TURBINE_STREAMS="http://ip1/hystrix.stream http://ip2/hystrix.stream"  can only pull data from ip1，because the double quotes can not pass to java command with "docker run -e"，so i add double quotes inside the Dockerfile, it works for me now under docker 1.5! 
